### PR TITLE
Fix IOError: No such file or directory: 'README.rst' při "pip install cstypo" (nová verze 0.1.13)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.md
-include README LICENSE
+include README.rst LICENSE
 recursive-include docs *.md


### PR DESCRIPTION
Při instalaci nové verze `cstypo 0.1.13` končí `pip` s chybou:

``` bash
(venv)***@***:/var/www/venv/***$ pip install cstypo
Downloading/unpacking cstypo
  Downloading cstypo-0.1.3.tar.gz
  Running setup.py egg_info for package cstypo
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/home/***/.virtualenvs/venv/build/cstypo/setup.py", line 13, in <module>
        long_description=open('README.rst').read(),
    IOError: [Errno 2] No such file or directory: 'README.rst'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/home/***/.virtualenvs/venv/build/cstypo/setup.py", line 13, in <module>

    long_description=open('README.rst').read(),

IOError: [Errno 2] No such file or directory: 'README.rst'

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /home/***/.virtualenvs/venv/build/cstypo
Storing complete log in /home/***/.pip/pip.log
```

```
Python 2.7.5
PIP 1.4.1
```
