### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,9 @@ základních a to hlavně těch, které jsou na webu nejvíce vidět.
     :target: https://travis-ci.org/yetty/cstypo
 .. image:: https://coveralls.io/repos/yetty/cstypo/badge.png?branch=master
     :target: https://coveralls.io/r/yetty/cstypo?branch=master
-.. image:: https://pypip.in/v/cstypo/badge.png
+.. image:: https://img.shields.io/pypi/v/cstypo.svg
     :target: https://crate.io/packages/cstypo/
-.. image:: https://pypip.in/d/cstypo/badge.png
+.. image:: https://img.shields.io/pypi/dm/cstypo.svg
     :target: https://crate.io/packages/cstypo/
 
 **Pozor!** Aplikování typografických pravidel na delší texty je poměrně výpočetně


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cstypo))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cstypo`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.